### PR TITLE
Remove println in requireDependencies

### DIFF
--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
@@ -146,8 +146,6 @@ final class CrossProject private[sbtcrossproject] (
       s"""|Project defines platforms: $projectPlatforms
           |$depedenciesInfo""".stripMargin
     }
-
-    if (hasMissing || hasDiscard) println(msg)
   }
 }
 


### PR DESCRIPTION
I think this will not emit the message when loading up the build.

If someone is interested in this message, the right way to implement it is in `Keys.onLoadMessage` with a way of disabling it with a special setting `crossProjectDisableLoadMessage`. This would mean creating an sbt plugin (if there's not already one).

Fix #52.