### PR TITLE
Get rid of bintray-sbt, and instead Do It Ourselves.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # How to publish
 
 * Be a member of https://bintray.com/portable-scala
-* `sbt`
-* `> bintrayChangeCredential`
-* `> publish`
+* Have your Bintray credentials stored as
+  [documented here](http://www.scala-sbt.org/1.0/docs/Publishing.html#Credentials),
+  using realm `Bintray API Realm` and host `api.bintray.com`
+* Use `publishSigned` from sbt
+* Log in to Bintray and publish the files that were sent

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,6 @@ lazy val `sbt-scalajs-crossproject` =
       }
     )
     .settings(publishSettings)
-    .enablePlugins(BintrayPlugin)
     .dependsOn(`sbt-crossproject`)
 
 lazy val `sbt-crossproject` =
@@ -42,7 +41,6 @@ lazy val `sbt-crossproject` =
     .settings(sbtPluginSettings)
     .settings(scaladocFromReadme)
     .settings(publishSettings)
-    .enablePlugins(BintrayPlugin)
 
 lazy val `sbt-crossproject-test` =
   project

--- a/project/Extra.scala
+++ b/project/Extra.scala
@@ -4,8 +4,6 @@ import ScriptedPlugin._
 
 import scala.util.Try
 
-import bintray.BintrayKeys.{bintrayRepository, bintrayOrganization}
-
 object Extra {
 
   val sbtPluginSettings = ScriptedPlugin.scriptedSettings ++ Seq(
@@ -45,8 +43,20 @@ object Extra {
           "scm:git:git@github.com:portable-scala/sbt-crossproject.git"
       )
     ),
-    bintrayRepository := "sbt-plugins",
-    bintrayOrganization := Some("portable-scala")
+    // Publish to Bintray, without the sbt-bintray plugin
+    publishMavenStyle := false,
+    publishTo := {
+      val proj = moduleName.value
+      val ver  = version.value
+      if (isSnapshot.value) {
+        None // Bintray does not support snapshots
+      } else {
+        val url = new java.net.URL(
+          s"https://api.bintray.com/content/portable-scala/sbt-plugins/$proj/$ver")
+        val patterns = Resolver.ivyStylePatterns
+        Some(Resolver.url("bintray", url)(patterns))
+      }
+    }
   )
 
   lazy val noPublishSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-addSbtPlugin("me.lessis"    % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp"     % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
It only takes a couple of lines to set up correct publishing to
Bintray, instead of relying on a pretty complex sbt plugin that
does who-knows-what.