### PR TITLE
Add `crossProject.withoutSuffixFor(platform)`.

### DIFF
--- a/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/bar/src/main/scala/Bar.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/bar/src/main/scala/Bar.scala
@@ -1,0 +1,3 @@
+object Bar {
+  val a = 42
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/build.sbt
@@ -1,0 +1,28 @@
+import sbtcrossproject.{crossProject, CrossType}
+
+lazy val check = taskKey[Unit]("check settings are applied")
+
+lazy val bar =
+  crossProject(JSPlatform, JVMPlatform, NativePlatform)
+    .withoutSuffixFor(JVMPlatform)
+    .crossType(CrossType.Pure)
+    .settings(
+      scalaVersion := "2.11.11",
+      description := "common settings"
+    )
+
+lazy val barJS     = bar.js
+lazy val barJVM    = bar.jvm
+lazy val barNative = bar.native
+
+check := {
+  def equals(actual: String, expected: String): Unit = {
+    if (actual != expected) {
+      assert(false, s"actual: $actual, expected: $expected")
+    }
+  }
+
+  equals(barJS.id, "barJS")
+  equals(barJVM.id, "bar")
+  equals(barNative.id, "barNative")
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/test
+++ b/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/test
@@ -1,0 +1,5 @@
+> check
+> barJS/compile
+> bar/compile
+> barNative/compile
+-> barJVM/compile

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProjectExtra.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProjectExtra.scala
@@ -49,28 +49,28 @@ object CrossProjectExtra {
         List(jsPlatform, jvmPlatform)
       }
 
-    val builderTerm =
+    val crossProjectCompanionTerm =
       Select(
         Select(
-          Select(
-            Ident(newTermName("_root_")),
-            newTermName("sbtcrossproject")
-          ),
-          newTermName("CrossProject")
+          Ident(newTermName("_root_")),
+          newTermName("sbtcrossproject")
         ),
-        newTypeName("Builder")
+        newTermName("CrossProject")
       )
 
-    val constructor =
+    val applyFun =
       Select(
-        New(builderTerm),
-        nme.CONSTRUCTOR
+        crossProjectCompanionTerm,
+        newTermName("apply")
       )
 
     c.Expr[CrossProject.Builder](
       Apply(
-        constructor,
-        List(name, javaIoFile) ::: platforms
+        Apply(
+          applyFun,
+          List(name, javaIoFile)
+        ),
+        platforms
       ))
   }
 


### PR DESCRIPTION
This method can be used if there is a "default" platform for the
project, which is more commonly used than the others. It will not
add the platform suffix for the given `platform`.

For example,
```scala
val foo = crossProject(JSPlatform, JVMPlatform, NativePlatform)
  .withoutPrefixFor(JVMPlatform)
  .settings(...)

val fooJS = foo.js
val fooJVM = foo.jvm
val fooNative = foo.native
```
will give the ID `foo` to `foo.jvm`, instead of the default `fooJVM`.
This then allows to run sbt tasks such as
```
> foo/test
```
instead of
```
> fooJVM/test
```
for the JVM.