### PR TITLE
Fix #83: Move `JSPlatform` back to `scalajscrossproject`

### DIFF
--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProjectExtra.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProjectExtra.scala
@@ -26,14 +26,8 @@ object CrossProjectExtra {
         val jsPlatform =
           Select(
             Select(
-              Select(
-                Select(
-                  Ident(newTermName("_root_")),
-                  newTermName("org")
-                ),
-                newTermName("scalajs")
-              ),
-              newTermName("sbtplugin")
+              Ident(newTermName("_root_")),
+              newTermName("scalajscrossproject")
             ),
             newTermName("JSPlatform")
           )

--- a/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/JSPlatform.scala
+++ b/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/JSPlatform.scala
@@ -1,11 +1,8 @@
-/* It is totally evil to introduce a class in the package of sbt-scalajs, but that is
- * the only way we can be forward source compatible with Scala.js 1.x.
- */
-package org.scalajs.sbtplugin
+package scalajscrossproject
 
 import sbtcrossproject._
-
 import sbt._
+import org.scalajs.sbtplugin._
 
 case object JSPlatform extends Platform {
   def identifier: String                = "js"

--- a/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/ScalaJSCross.scala
+++ b/sbt-scalajs-crossproject/src/main/scala/scalajscrossproject/ScalaJSCross.scala
@@ -9,7 +9,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin
 import scala.language.implicitConversions
 
 trait ScalaJSCross {
-  val JSPlatform = org.scalajs.sbtplugin.JSPlatform
+  val JSPlatform = scalajscrossproject.JSPlatform
 
   implicit def JSCrossProjectBuilderOps(
       builder: CrossProject.Builder): JSCrossProjectOps =


### PR DESCRIPTION
Review: @sjrd 