### PR TITLE
Introduce `sbt-scala-native-crossproject`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 script:
   - java -version
   - scripts/scalafmt --test && sbt sbt-crossproject-test/scripted
-  - sbt "++ 2.12.3" "^^ 1.0.0" sbt-crossproject/publishLocal sbt-scalajs-crossproject/publishLocal
+  - sbt "++ 2.12.3" "^^ 1.0.0" sbt-crossproject/publishLocal sbt-scalajs-crossproject/publishLocal sbt-scala-native-crossproject/publishLocal
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -14,28 +14,29 @@ Cross-platform compilation support for sbt.
 In `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.21")
-addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "0.3.1")  // (1)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.1")  // (2)
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"         % "0.3.6")  // (3)
+addSbtPlugin("org.portable-scala" % "sbt-crossproject"              % "0.4.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.4.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.22")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.4.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
 ```
 
 In `build.sbt`:
 
 ```scala
-// (5) shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
+// shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
 import sbtcrossproject.{crossProject, CrossType}
 
 val sharedSettings = Seq(scalaVersion := "2.11.12")
 
 lazy val bar =
-  // (6) select supported platforms
+  // select supported platforms
   crossProject(JSPlatform, JVMPlatform, NativePlatform)
     .crossType(CrossType.Pure) // [Pure, Full, Dummy], default: CrossType.Full
     .settings(sharedSettings)
     .jsSettings(/* ... */) // defined in sbt-scalajs-crossproject
     .jvmSettings(/* ... */)
-    // (7) configure Scala-Native settings
+    // configure Scala-Native settings
     .nativeSettings(/* ... */) // defined in sbt-scala-native
 
 lazy val barJS     = bar.js
@@ -90,8 +91,9 @@ Note that *inside the build*, you still need to use `barJVM` to the JVM `Project
 In `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.3.1") // (1)
-addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.3.6") // (2)
+addSbtPlugin("org.portable-scala" % "sbt-crossproject"              % "0.4.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.4.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
 ```
 
 In `build.sbt`:
@@ -100,12 +102,12 @@ In `build.sbt`:
 val sharedSettings = Seq(scalaVersion := "2.11.12")
 
 lazy val bar =
-  // (4) select supported platforms
+  // select supported platforms
   crossProject(JVMPlatform, NativePlatform)
     .settings(sharedSettings)
-    // (5) configure JVM settings
+    // configure JVM settings
     .jvmSettings(/* ... */)
-    // (6) configure Scala-Native settings
+    // configure Scala-Native settings
     .nativeSettings(/* ... */) // defined in sbt-scala-native
 
 lazy val barJVM    = bar.jvm
@@ -119,19 +121,19 @@ We carefully implemented sbt-crossproject to be mostly source compatible with Sc
 In `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.21")
-addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "0.3.1")  // (1)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.1")  // (2)
+addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "0.4.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.22")
 ```
 
 In `build.sbt`:
 
 ```scala
-// (5) shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
+// shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
 import sbtcrossproject.{crossProject, CrossType}
 
 lazy val bar =
-  // (4) select supported platforms
+  // select supported platforms
   crossProject(JSPlatform, JVMPlatform)
     .crossType(CrossType.Pure) // [Pure, Full, Dummy], default: CrossType.Full
     .settings(/* ... */)

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ Cross-platform compilation support for sbt.
 In `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.portable-scala" % "sbt-crossproject"              % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.4.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.22")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.4.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.22")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
 ```
 
@@ -91,7 +90,6 @@ Note that *inside the build*, you still need to use `barJVM` to the JVM `Project
 In `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.portable-scala" % "sbt-crossproject"              % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.4.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
 ```
@@ -121,7 +119,6 @@ We carefully implemented sbt-crossproject to be mostly source compatible with Sc
 In `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.4.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.22")
 ```

--- a/README.md
+++ b/README.md
@@ -145,11 +145,10 @@ lazy val barJVM = bar.jvm
 
 ```
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
-import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
+import sbtcrossproject.{crossProject, CrossType}
 import sbtcrossproject.CrossPlugin.autoImport._
 import scalajscrossproject.ScalaJSCrossPlugin.autoImport.{toScalaJSGroupID => _, _}
-import scalajscrossproject.ScalaJSCrossPlugin.autoImport.JSPlatform
-import sbtcrossproject.{crossProject, CrossType}
+import scalanativecrossproject.ScalaNativeCrossPlugin.autoImport._
 ```
 
 <h2>Configuration</h2>

--- a/build.sbt
+++ b/build.sbt
@@ -72,8 +72,8 @@ lazy val `sbt-crossproject-test` =
       scripted := scripted
         .dependsOn(
           publishLocal in `sbt-crossproject`,
-          publishLocal in `sbt-scalajs-crossproject`
-            publishLocal in `sbt-scala-native-crossproject`
+          publishLocal in `sbt-scalajs-crossproject`,
+          publishLocal in `sbt-scala-native-crossproject`
         )
         .evaluated
     )

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,20 @@ lazy val `sbt-scalajs-crossproject` =
       moduleName := "sbt-scalajs-crossproject",
       addSbtPluginWorkaround(
         "org.portable-scala"                % "sbt-platform-deps" % "1.0.0-M2"),
-      addSbtPluginWorkaround("org.scala-js" % "sbt-scalajs"       % "0.6.19")
+      addSbtPluginWorkaround("org.scala-js" % "sbt-scalajs"       % "0.6.22")
+    )
+    .settings(publishSettings)
+    .dependsOn(`sbt-crossproject`)
+
+lazy val `sbt-scala-native-crossproject` =
+  project
+    .in(file("sbt-scala-native-crossproject"))
+    .settings(sbtPluginSettings)
+    .settings(
+      moduleName := "sbt-scala-native-crossproject",
+      addSbtPluginWorkaround(
+        "org.portable-scala"                    % "sbt-platform-deps" % "1.0.0-M2"),
+      addSbtPluginWorkaround("org.scala-native" % "sbt-scala-native"  % "0.3.7")
     )
     .settings(publishSettings)
     .dependsOn(`sbt-crossproject`)

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,11 @@ lazy val `sbt-crossproject-root` =
   project
     .in(file("."))
     .aggregate(`sbt-scalajs-crossproject`,
+               `sbt-scala-native-crossproject`,
                `sbt-crossproject`,
                `sbt-crossproject-test`)
     .dependsOn(`sbt-scalajs-crossproject`,
+               `sbt-scala-native-crossproject`,
                `sbt-crossproject`,
                `sbt-crossproject-test`)
     .settings(noPublishSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ lazy val `sbt-crossproject-test` =
         .dependsOn(
           publishLocal in `sbt-crossproject`,
           publishLocal in `sbt-scalajs-crossproject`
+            publishLocal in `sbt-scala-native-crossproject`
         )
         .evaluated
     )

--- a/project/Extra.scala
+++ b/project/Extra.scala
@@ -21,9 +21,7 @@ object Extra {
         "-feature",
         "-encoding",
         "utf8"
-      ),
-      resolvers +=
-        "Sonatype Staging" at "https://oss.sonatype.org/content/repositories/staging"
+      )
     )
 
   // to publish plugin (we only need to do this once, it's already done!)

--- a/project/Extra.scala
+++ b/project/Extra.scala
@@ -12,8 +12,8 @@ object Extra {
       sbtPlugin := true,
       scriptedLaunchOpts ++= Seq(
         "-Dplugin.version=" + version.value,
-        "-Dplugin.sn-version=0.3.3",
-        "-Dplugin.sjs-version=0.6.19"
+        "-Dplugin.sn-version=0.3.7",
+        "-Dplugin.sjs-version=0.6.22"
       ),
       scalacOptions ++= Seq(
         "-deprecation",
@@ -21,7 +21,9 @@ object Extra {
         "-feature",
         "-encoding",
         "utf8"
-      )
+      ),
+      resolvers +=
+        "Sonatype Staging" at "https://oss.sonatype.org/content/repositories/staging"
     )
 
   // to publish plugin (we only need to do this once, it's already done!)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/sbt-crossproject-test/src/sbt-test/new-api/scala-native-only/project/plugins.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/scala-native-only/project/plugins.sbt
@@ -1,6 +1,9 @@
-val snVersion = sys.props.get("plugin.sn-version").get
+val pluginVersion = sys.props.get("plugin.version").get
+val snVersion     = sys.props.get("plugin.sn-version").get
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % snVersion)
+addSbtPlugin(
+  "org.portable-scala"          % "sbt-scala-native-crossproject" % pluginVersion)
+addSbtPlugin("org.scala-native" % "sbt-scala-native"              % snVersion)
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/sbt-crossproject-test/src/sbt-test/plugins.sbt
+++ b/sbt-crossproject-test/src/sbt-test/plugins.sbt
@@ -1,12 +1,14 @@
 // COPIED FROM sbt-crossproject-test/src/sbt-test/plugins.sbt
 val pluginVersion = sys.props.get("plugin.version").get
-val snVersion     = sys.props.get("plugin.sn-version").get
 val sjsVersion    = sys.props.get("plugin.sjs-version").get
+val snVersion     = sys.props.get("plugin.sn-version").get
 
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % sjsVersion)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % pluginVersion)
 addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % pluginVersion)
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"         % snVersion)
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % pluginVersion)
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % sjsVersion)
+addSbtPlugin(
+  "org.portable-scala"          % "sbt-scala-native-crossproject" % pluginVersion)
+addSbtPlugin("org.scala-native" % "sbt-scala-native"              % snVersion)
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/sbt-crossproject-test/src/sbt-test/plugins.sbt
+++ b/sbt-crossproject-test/src/sbt-test/plugins.sbt
@@ -3,11 +3,10 @@ val pluginVersion = sys.props.get("plugin.version").get
 val sjsVersion    = sys.props.get("plugin.sjs-version").get
 val snVersion     = sys.props.get("plugin.sn-version").get
 
-addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % pluginVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % pluginVersion)
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % sjsVersion)
 addSbtPlugin(
   "org.portable-scala"          % "sbt-scala-native-crossproject" % pluginVersion)
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"                   % sjsVersion)
 addSbtPlugin("org.scala-native" % "sbt-scala-native"              % snVersion)
 
 scalacOptions ++= Seq(

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/NativePlatform.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/NativePlatform.scala
@@ -1,0 +1,14 @@
+package scalanativecrossproject
+
+import sbt._
+import sbtcrossproject._
+import scalanative.sbtplugin._
+
+case object NativePlatform extends Platform {
+  def identifier: String = "native"
+  def sbtSuffix: String  = "Native"
+  def enable(project: Project): Project =
+    project.enablePlugins(ScalaNativePlugin)
+  val crossBinary: CrossVersion = ScalaNativeCrossVersion.binary
+  val crossFull: CrossVersion   = ScalaNativeCrossVersion.full
+}

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/NativePlatform.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/NativePlatform.scala
@@ -9,6 +9,10 @@ case object NativePlatform extends Platform {
   def sbtSuffix: String  = "Native"
   def enable(project: Project): Project =
     project.enablePlugins(ScalaNativePlugin)
+
+  @deprecated("Will be removed", "0.3.0")
   val crossBinary: CrossVersion = ScalaNativeCrossVersion.binary
-  val crossFull: CrossVersion   = ScalaNativeCrossVersion.full
+
+  @deprecated("Will be removed", "0.3.0")
+  val crossFull: CrossVersion = ScalaNativeCrossVersion.full
 }

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCross.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCross.scala
@@ -1,0 +1,25 @@
+package scalanativecrossproject
+
+import sbt._
+import sbtcrossproject._
+import scalanative.sbtplugin._
+
+import scala.language.implicitConversions
+
+trait ScalaNativeCross {
+  val NativePlatform = scalanativecrossproject.NativePlatform
+
+  implicit def NativeCrossProjectBuilderOps(
+      builder: CrossProject.Builder): NativeCrossProjectOps =
+    new NativeCrossProjectOps(builder.crossType(CrossType.Full))
+
+  implicit class NativeCrossProjectOps(project: CrossProject) {
+    def native: Project = project.projects(NativePlatform)
+
+    def nativeSettings(ss: Def.SettingsDefinition*): CrossProject =
+      nativeConfigure(_.settings(ss: _*))
+
+    def nativeConfigure(transformer: Project => Project): CrossProject =
+      project.configurePlatform(NativePlatform)(transformer)
+  }
+}

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
@@ -1,6 +1,6 @@
 package scalanativecrossproject
 
-import sbt._
+import sbt._, Keys._
 import scalanative.sbtplugin._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
@@ -15,6 +15,8 @@ object ScalaNativeCrossPlugin extends AutoPlugin {
   import autoImport._
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    platformDepsCrossVersion := ScalaNativeCrossVersion.binary
+    platformDepsCrossVersion := ScalaNativeCrossVersion.binary,
+    resolvers +=
+      "Sonatype Staging" at "https://oss.sonatype.org/content/repositories/staging"
   )
 }

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
@@ -11,11 +11,4 @@ object ScalaNativeCrossPlugin extends AutoPlugin {
   override def requires: Plugins = ScalaNativePlugin
 
   object autoImport extends ScalaNativeCross
-
-  import autoImport._
-
-  override def projectSettings: Seq[Setting[_]] = Seq(
-    resolvers +=
-      "Sonatype Staging" at "https://oss.sonatype.org/content/repositories/staging"
-  )
 }

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
@@ -1,0 +1,20 @@
+package scalanativecrossproject
+
+import sbt._
+import scalanative.sbtplugin._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+
+import scala.language.implicitConversions
+
+object ScalaNativeCrossPlugin extends AutoPlugin {
+  override def trigger           = allRequirements
+  override def requires: Plugins = ScalaNativePlugin
+
+  object autoImport extends ScalaNativeCross
+
+  import autoImport._
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    platformDepsCrossVersion := ScalaNativeCrossVersion.binary
+  )
+}

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
@@ -1,14 +1,5 @@
 package scalanativecrossproject
 
-import sbt._, Keys._
-import scalanative.sbtplugin._
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
-
-import scala.language.implicitConversions
-
-object ScalaNativeCrossPlugin extends AutoPlugin {
-  override def trigger           = allRequirements
-  override def requires: Plugins = ScalaNativePlugin
-
+object ScalaNativeCrossPlugin extends sbt.AutoPlugin {
   object autoImport extends ScalaNativeCross
 }

--- a/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
+++ b/sbt-scala-native-crossproject/src/main/scala/scalanativecrossproject/ScalaNativeCrossPlugin.scala
@@ -15,7 +15,6 @@ object ScalaNativeCrossPlugin extends AutoPlugin {
   import autoImport._
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    platformDepsCrossVersion := ScalaNativeCrossVersion.binary,
     resolvers +=
       "Sonatype Staging" at "https://oss.sonatype.org/content/repositories/staging"
   )


### PR DESCRIPTION
This PR introduces `sbt-scala-native-crossproject` with identical functionality to `sbt-scalajs-crossproject`. It's a blocker for `0.3.7` release as it doesn't depend on old sbt-crossproject any longer, and requires platforms-deps based cross projects instead.