### PR TITLE
toScalaJSGroupID removed since 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ lazy val barJVM = bar.jvm
 ```
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType, _}
-import scalajscrossproject.ScalaJSCrossPlugin.autoImport.{toScalaJSGroupID => _, _}
+import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
 import scalanativecrossproject.ScalaNativeCrossPlugin.autoImport._
 ```
 


### PR DESCRIPTION
https://github.com/portable-scala/sbt-crossproject/commit/e7b769a95a24df24d777d7a03eb1f3659a9fcc25#diff-416e265545ba486917b9ae2e9d8972eeL17