### PR TITLE
fix foo example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ lazy val barNative = bar.native
 
 lazy val foo =
   crossProject(JSPlatform, JVMPlatform, NativePlatform)
+    .settings(sharedSettings)
     .settings(
       // %%% now include Scala Native. It applies to all selected platforms
       libraryDependencies += "org.example" %%% "foo" % "1.2.3"


### PR DESCRIPTION
The given example failed `sbt update` because the scala version in `sharedSettings` wasn't applied to `foo` subproject.

update also fails because `"org.example" %%% "foo" % "1.2.3"` doesn't exist, but that's more obvious :)