### PR TITLE
Allow the build to detect the current platform

### DIFF
--- a/sbt-crossproject-test/src/sbt-test/new-api/detection/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/detection/build.sbt
@@ -1,0 +1,23 @@
+import sbtcrossproject.{crossProject, CrossType, Platform}
+
+lazy val check = taskKey[Unit]("check")
+
+def doCheck(platform: Platform, id: String) =
+  assert(platform.identifier == id)
+
+lazy val root =
+  crossProject(JVMPlatform, NativePlatform, JSPlatform)
+    .crossType(CrossType.Pure)
+    .jvmSettings(
+      check := doCheck(crossProjectPlatform.value, "jvm")
+    )
+    .jsSettings(
+      check := doCheck(crossProjectPlatform.value, "js")
+    )
+    .nativeSettings(
+      check := doCheck(crossProjectPlatform.value, "native")
+    )
+
+lazy val rootJVM = root.jvm
+lazy val rootJS = root.js
+lazy val rootNative = root.native

--- a/sbt-crossproject-test/src/sbt-test/new-api/detection/test
+++ b/sbt-crossproject-test/src/sbt-test/new-api/detection/test
@@ -1,0 +1,3 @@
+> rootJVM/check
+> rootJS/check
+> rootNative/check

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossPlugin.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossPlugin.scala
@@ -56,5 +56,8 @@ object CrossPlugin extends AutoPlugin {
         project.configurePlatform(JVMPlatform)(transformer)
     }
 
+    lazy val crossProjectPlatform =
+      settingKey[Platform]("platform of the current project")
+
   }
 }

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossProject.scala
@@ -195,6 +195,7 @@ object CrossProject {
               projectID,
               crossType.platformDir(base, platform)
             ).settings(
+              CrossPlugin.autoImport.crossProjectPlatform := platform,
               name := id, // #80
               sharedSrc
             )


### PR DESCRIPTION
This could be used subsequently by other settings, e.g. generating an appropriate `BuildInfo` object.