### PR TITLE
Upgrade the macOS image in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       language: scala
 
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.2
 
 before_install:
   - curl -O https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh


### PR DESCRIPTION
It appears that XCode 7.3 implies macOS 10.11 (see [docs](https://docs.travis-ci.com/user/reference/osx/#xcode-version)), for which Homebrew has to compile packages instead of installing them as binaries. Consequently, the Scala Native setup takes way too long.

macOS 10.12 is the earliest macOS version for which Homebrew has binaries for LLVM.