### PR TITLE
Add support for partially-shared source directories

### DIFF
--- a/project/Extra.scala
+++ b/project/Extra.scala
@@ -13,7 +13,7 @@ object Extra {
 
   val sbtPluginSettings = Def.settings(
     organization := "org.portable-scala",
-    version := "1.1.1-SNAPSHOT",
+    version := "1.2.0-SNAPSHOT",
     versionScheme := Some("semver-spec"),
     scalacOptions ++= Seq(
       "-deprecation",

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/build.sbt
@@ -1,0 +1,5 @@
+import sbtcrossproject.{crossProject, CrossType}
+
+lazy val foo = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .settings(scalaVersion := "2.11.11")
+  .jsSettings(scalaJSUseMainModuleInitializer := true)

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js-jvm/src/main/scala/JSOrJVM.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js-jvm/src/main/scala/JSOrJVM.scala
@@ -1,0 +1,3 @@
+object JSOrJVM {
+  def check = true
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js-native/src/main/scala/JSOrNative.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js-native/src/main/scala/JSOrNative.scala
@@ -1,0 +1,3 @@
+object JSOrNative {
+  def check = true
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js/src/main/scala/JVMOrNative.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js/src/main/scala/JVMOrNative.scala
@@ -1,0 +1,3 @@
+object JVMOrNative {
+  def check = false
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js/src/main/scala/Platform.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/js/src/main/scala/Platform.scala
@@ -1,0 +1,5 @@
+object Platform {
+  def isJVM    = false
+  def isJS     = true
+  def isNative = false
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/jvm-native/src/main/scala/JVMOrNative.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/jvm-native/src/main/scala/JVMOrNative.scala
@@ -1,0 +1,3 @@
+object JVMOrNative {
+  def check = true
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/jvm/src/main/scala/JSOrNative.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/jvm/src/main/scala/JSOrNative.scala
@@ -1,0 +1,3 @@
+object JSOrNative {
+  def check = false
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/jvm/src/main/scala/Platform.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/jvm/src/main/scala/Platform.scala
@@ -1,0 +1,5 @@
+object Platform {
+  def isJVM    = true
+  def isJS     = false
+  def isNative = false
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/native/src/main/scala/JSOrJVM.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/native/src/main/scala/JSOrJVM.scala
@@ -1,0 +1,3 @@
+object JSOrJVM {
+  def check = false
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/native/src/main/scala/Platform.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/native/src/main/scala/Platform.scala
@@ -1,0 +1,5 @@
+object Platform {
+  def isJVM    = false
+  def isJS     = false
+  def isNative = true
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/shared/src/main/scala/Foo.scala
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/foo/shared/src/main/scala/Foo.scala
@@ -1,0 +1,13 @@
+import Platform._
+object Foo {
+  def main(args: Array[String]): Unit = {
+    assert(List(isJVM, isJS, isNative).count(identity) == 1)
+
+    if (isJVM)
+      assert(JSOrJVM.check && JVMOrNative.check && !JSOrNative.check)
+    if (isJS)
+      assert(JSOrJVM.check && !JVMOrNative.check && JSOrNative.check)
+    if (isNative)
+      assert(!JSOrJVM.check && JVMOrNative.check && JSOrNative.check)
+  }
+}

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/test
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/test
@@ -1,0 +1,3 @@
+> fooJVM/run
+> fooJS/run
+> fooNative/run 

--- a/sbt-crossproject/src/main/scala/sbtcrossproject/CrossType.scala
+++ b/sbt-crossproject/src/main/scala/sbtcrossproject/CrossType.scala
@@ -37,12 +37,31 @@ abstract class CrossType {
    */
   def sharedSrcDir(projectBase: File, conf: String): Option[File]
 
+  /** The location of a partially shared source directory (if it exists)
+   *  @param projectBase the base directory of a (true sbt) Project
+   *  @param platforms non-empty seq of JSPlatform, JVMPlatform, NativePlatform, ...
+   *  @param conf name of sub-directory for the configuration (typically "main"
+   *      or "test")
+   */
+  def partiallySharedSrcDir(projectBase: File,
+                            platforms: Seq[Platform],
+                            conf: String): Option[File] = None
+
   /** The location of a shared resources directory (if it exists)
    *  @param projectBase the base directory of a (true sbt) Project
    *  @param conf name of sub-directory for the configuration (typically "main"
    *      or "test")
    */
   def sharedResourcesDir(projectBase: File, conf: String): Option[File] = None
+
+  /** The location of a partially shared resources directory (if it exists)
+   *  @param projectBase the base directory of a (true sbt) Project
+   *  @param conf name of sub-directory for the configuration (typically "main"
+   *      or "test")
+   */
+  def partiallySharedResourcesDir(projectBase: File,
+                                  platforms: Seq[Platform],
+                                  conf: String): Option[File] = None
 
 }
 
@@ -69,9 +88,23 @@ object CrossType {
     def sharedSrcDir(projectBase: File, conf: String): Option[File] =
       Some(projectBase.getParentFile / "shared" / "src" / conf / "scala")
 
+    override def partiallySharedSrcDir(projectBase: File,
+                                       platforms: Seq[Platform],
+                                       conf: String): Option[File] = {
+      val dir = platforms.map(_.identifier).mkString("-")
+      Some(projectBase.getParentFile / dir / "src" / conf / "scala")
+    }
+
     override def sharedResourcesDir(projectBase: File,
                                     conf: String): Option[File] =
       Some(projectBase.getParentFile / "shared" / "src" / conf / "resources")
+
+    override def partiallySharedResourcesDir(projectBase: File,
+                                             platforms: Seq[Platform],
+                                             conf: String): Option[File] = {
+      val dir = platforms.map(_.identifier).mkString("-")
+      Some(projectBase.getParentFile / dir / "src" / conf / "resources")
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/portable-scala/sbt-crossproject/issues/17.

For a full-cross-project set up for platforms `a`, `b`, `c`, `d`, etc. (in this order), configures the standard source and resource directories under these directories:
- `a-b`
- `a-c`
- `a-d`
- `b-c`
- `b-d`
- `c-d`
- `a-b-c`
- `a-b-d`
- `a-c-d`
- `b-c-d`

This is in addition to the already supported `shared`, `a`, `b`, `c`, and `d` directories.