### PR TITLE
Update to Scala Native 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements:
 
 * sbt 1.2.1+
 * For `JSPlatform`: Scala.js 0.6.23+ or 1.0.0+
-* For `NativePlatform`: Scala Native 0.3.7+
+* For `NativePlatform`: Scala Native 0.4.0+
 
 If you are still using sbt 0.13.x, you must use sbt-crossproject v0.6.1 instead of v1.2.0.
 
@@ -25,7 +25,7 @@ In `project/plugins.sbt`:
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.2.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "1.0.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0")
 ```
 
 In `build.sbt`:
@@ -119,7 +119,7 @@ In `project/plugins.sbt`:
 
 ```scala
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.0")
 ```
 
 In `build.sbt`:

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val `sbt-scala-native-crossproject` =
     .settings(
       moduleName := "sbt-scala-native-crossproject",
       addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0"),
-      addSbtPlugin("org.scala-native"   % "sbt-scala-native"  % "0.3.7")
+      addSbtPlugin("org.scala-native"   % "sbt-scala-native"  % "0.4.0")
     )
     .settings(publishSettings)
     .dependsOn(`sbt-crossproject`)
@@ -65,7 +65,7 @@ lazy val `sbt-crossproject-test` =
     .settings(
       scriptedLaunchOpts ++= Seq(
         "-Dplugin.version=" + version.value,
-        "-Dplugin.sn-version=0.3.7",
+        "-Dplugin.sn-version=0.4.0",
         "-Dplugin.sjs-version=0.6.23"
       ),
       scripted := scripted

--- a/project/Extra.scala
+++ b/project/Extra.scala
@@ -13,7 +13,7 @@ object Extra {
 
   val sbtPluginSettings = Def.settings(
     organization := "org.portable-scala",
-    version := "1.2.1-SNAPSHOT",
+    version := "1.3.0-SNAPSHOT",
     versionScheme := Some("semver-spec"),
     scalacOptions ++= Seq(
       "-deprecation",


### PR DESCRIPTION
```
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error]         * org.scala-native:sbt-scala-native:0.4.8 (early-semver) is selected over 0.3.7
[error]             +- default:scodec-bits-build:0.1.0-SNAPSHOT (sbtVersion=1.0, scalaVersion=2.12) (depends on 0.4.8)
[error]             +- org.portable-scala:sbt-scala-native-crossproject:1.2.0 (sbtVersion=1.0, scalaVersion=2.12) (depends on 0.3.7)
```

I bumped the sbt-crossproject minor to account for this. Otherwise if we need a major bump then I guess that sbt-scala-native-crossproject should be versioned independently.

We will have this problem again soon when Scala Native 0.5 releases.