### PR TITLE
[doc] Add section to README on non-flat directory structures for pojects

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,48 @@ This layout gives full control by providing a `shared` directory for common code
 - `.crossType({/*custom*/})`
 
 One can easily extend CrossType and provide a custom tree structure.
+
+<h3>Customizing Directory Structure for Complex Projects</h3>
+
+For complex projects it can be desirable to adopt a non-flat directory structure.
+
+SBT provides an `in file("path")` mechanism for multi-project builds ( https://www.scala-sbt.org/1.x/docs/Multi-Project.html )
+
+CrossProject also has support, for example:
+
+```
+.
+├── apps
+│   ├── a
+│   └── b
+└── lib
+    ├── a
+    ├── b
+    └── c
+```
+
+can be configured as a normal `CrossProject` with
+
+```
+lazy val appA = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("app/a"))
+  .dependsOn(libA, libB)
+
+lazy val appB = crossProject(JVMPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .in(file("app/b"))
+  .dependsOn(libB, libC)
+
+lazy val libA = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("lib/a"))
+
+lazy val libB = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .in(file("lib/b"))
+
+lazy val libC = crossProject(JVMPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .in(file("lib/c"))
+```


### PR DESCRIPTION
I was attempting to use sbt `in file("path")` but in a weird way which was giving me the following error: 

```
java.util.NoSuchElementException: key not found: JVMPlatform
    at scala.collection.MapLike.default(MapLike.scala:236)
    at scala.collection.MapLike.default$(MapLike.scala:235)
    at scala.collection.AbstractMap.default(Map.scala:65)
    at scala.collection.MapLike.apply(MapLike.scala:144)
    at scala.collection.MapLike.apply$(MapLike.scala:143)
    at scala.collection.AbstractMap.apply(Map.scala:65)
    at sbtcrossproject.CrossProject.$anonfun$dependsOn$7(CrossProject.scala:45)
    at sbtcrossproject.CrossProject.$anonfun$mapProjectsByPlatform$1(CrossProject.scala:111)
    at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
    at scala.collection.immutable.Map$Map3.foreach(Map.scala:376)
    at scala.collection.TraversableLike.map(TraversableLike.scala:286)
    at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
    at scala.collection.AbstractTraversable.map(Traversable.scala:108)
    at sbtcrossproject.CrossProject.mapProjectsByPlatform(CrossProject.scala:110)
    at sbtcrossproject.CrossProject.dependsOn(CrossProject.scala:44)
```

I think this doc addition might help others get started with more complex build structures.

Thanks @armanbilge for the help on Typelevel's Discord! 