### PR TITLE
Upgrade to sbt-ci-release 1.11.2.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"  % "1.5.11")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"  % "1.11.2")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "0.8.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
This is necessary to publish on the new Sonatype infrastructure.