### PR TITLE
Run most of the scripted tests on sbt 2.x as well.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Test sbt 1
         run: sbt sbt-crossproject-test/scripted
       - name: Test sbt 2
-        run: sbt '++ 3.x' "sbt-crossproject/test ; sbt-scala-native-crossproject/test"
+        run: sbt '++ 3.x' sbt-crossproject-test/scripted

--- a/sbt-crossproject-test/src/sbt-test/backward-compatible/cross-classpath/project/build.properties
+++ b/sbt-crossproject-test/src/sbt-test/backward-compatible/cross-classpath/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/sbt-crossproject-test/src/sbt-test/backward-compatible/example/project/build.properties
+++ b/sbt-crossproject-test/src/sbt-test/backward-compatible/example/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/sbt-crossproject-test/src/sbt-test/new-api/aggregates/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/aggregates/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val bar = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .settings(scalaVersion := "2.12.17")

--- a/sbt-crossproject-test/src/sbt-test/new-api/composite-project/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/composite-project/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val bar = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .settings(scalaVersion := "2.12.17")

--- a/sbt-crossproject-test/src/sbt-test/new-api/cross-dependencies-without-cross/project/build.properties
+++ b/sbt-crossproject-test/src/sbt-test/new-api/cross-dependencies-without-cross/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/sbt-crossproject-test/src/sbt-test/new-api/cross-dependencies/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/cross-dependencies/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 val g = "org.example.cross-dependencies"
 val a = "bar"
 val v = "0.1.0"

--- a/sbt-crossproject-test/src/sbt-test/new-api/cross-dependencies/project/build.properties
+++ b/sbt-crossproject-test/src/sbt-test/new-api/cross-dependencies/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/sbt-crossproject-test/src/sbt-test/new-api/dependsOn/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/dependsOn/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val bar = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .settings(scalaVersion := "2.12.17")

--- a/sbt-crossproject-test/src/sbt-test/new-api/detection/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/detection/build.sbt
@@ -1,5 +1,6 @@
 import sbtcrossproject.Platform
 
+@transient
 lazy val check = taskKey[Unit]("check")
 
 def doCheckPlatform(platform: Platform, id: String) =

--- a/sbt-crossproject-test/src/sbt-test/new-api/detection/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/detection/build.sbt
@@ -1,4 +1,4 @@
-import sbtcrossproject.{crossProject, CrossType, Platform}
+import sbtcrossproject.Platform
 
 lazy val check = taskKey[Unit]("check")
 

--- a/sbt-crossproject-test/src/sbt-test/new-api/exceeding-aggregates/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/exceeding-aggregates/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val bar = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .settings(scalaVersion := "2.12.17")

--- a/sbt-crossproject-test/src/sbt-test/new-api/global-cross-dependencies/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/global-cross-dependencies/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 val g = "org.example.cross-dependencies-global"
 val a = "bar"
 val v = "0.1.0"

--- a/sbt-crossproject-test/src/sbt-test/new-api/global-cross-dependencies/project/build.properties
+++ b/sbt-crossproject-test/src/sbt-test/new-api/global-cross-dependencies/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/sbt-crossproject-test/src/sbt-test/new-api/missing-aggregates/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/missing-aggregates/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val bar = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
   .settings(scalaVersion := "2.12.17")

--- a/sbt-crossproject-test/src/sbt-test/new-api/name/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/name/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val check = taskKey[Unit]("check name")
 
 lazy val bar =

--- a/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/partially-shared-sources/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val foo = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(scalaVersion := "2.12.17")
   .jsSettings(scalaJSUseMainModuleInitializer := true)

--- a/sbt-crossproject-test/src/sbt-test/new-api/platform-specific/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/platform-specific/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 val g = "org.example.platform-specific"
 val a = "bar"
 val v = "0.1.0"

--- a/sbt-crossproject-test/src/sbt-test/new-api/platform-specific/project/build.properties
+++ b/sbt-crossproject-test/src/sbt-test/new-api/platform-specific/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/sbt-crossproject-test/src/sbt-test/new-api/plugins/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/plugins/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val check = taskKey[Unit]("check settings are applied")
 
 Global / checkedSettingSet := Set("global")

--- a/sbt-crossproject-test/src/sbt-test/new-api/settings/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/settings/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val check = taskKey[Unit]("check settings are applied")
 
 lazy val bar =

--- a/sbt-crossproject-test/src/sbt-test/new-api/shared-cross-sources/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/shared-cross-sources/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val foo = crossProject(JVMPlatform).settings(
   crossScalaVersions := Seq("2.12.17", "2.13.9", "3.0.0")
 )

--- a/sbt-crossproject-test/src/sbt-test/new-api/shared-resources/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/shared-resources/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val foo = crossProject(JVMPlatform).settings(
   scalaVersion := "2.12.17"
 )

--- a/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/build.sbt
+++ b/sbt-crossproject-test/src/sbt-test/new-api/without-suffix-for/build.sbt
@@ -1,5 +1,3 @@
-import sbtcrossproject.{crossProject, CrossType}
-
 lazy val check = taskKey[Unit]("check settings are applied")
 
 lazy val bar =


### PR DESCRIPTION
We exclude `backward-compatible` tests, since they are indeed not supported anymore.

Unfortunately we also have to exclude tests using `%%%`. It does not exist in sbt 2.x anymore. It was replaced by `%%`, which takes on its behavior. I did not manage to adapt those tests in a cross-compilable way.